### PR TITLE
Adding form messages to the Forms tab

### DIFF
--- a/zray.php
+++ b/zray.php
@@ -99,7 +99,8 @@ class ZF2 {
 	    
     	$storage['forms'][get_class($form)] = array(   'label'      => $form->getLabel(),
                     	                               'elements'   => $form->getElements(),
-                    	                               'attributes' => $form->getAttributes());
+                    	                               'attributes' => $form->getAttributes(),
+                    	                               'messages'   => $form->getMessages());
 	}
 	
 	////////////////////////////////////////////////////////////////


### PR DESCRIPTION
It's useful to see the form validation messages, specially if the view presents just generic ones or none at all.
